### PR TITLE
Corrects the pipelines API path

### DIFF
--- a/src/Api/Repositories/Users/Pipelines.php
+++ b/src/Api/Repositories/Users/Pipelines.php
@@ -86,6 +86,6 @@ class Pipelines extends AbstractUsersApi
      */
     protected function buildPipelinesPath(string ...$parts)
     {
-        return static::buildPath('repositories', $this->username, $this->repo, 'pipelines', ...$parts);
+        return static::buildPath('repositories', $this->username, $this->repo, 'pipelines/', ...$parts);
     }
 }

--- a/src/Api/Repositories/Users/Pipelines.php
+++ b/src/Api/Repositories/Users/Pipelines.php
@@ -31,7 +31,7 @@ class Pipelines extends AbstractUsersApi
      */
     public function list(array $params = [])
     {
-        $path = $this->buildPipelinesPath();
+        $path = $this->buildPipelinesPath() . '/';
 
         return $this->get($path, $params);
     }
@@ -86,6 +86,6 @@ class Pipelines extends AbstractUsersApi
      */
     protected function buildPipelinesPath(string ...$parts)
     {
-        return static::buildPath('repositories', $this->username, $this->repo, 'pipelines/', ...$parts);
+        return static::buildPath('repositories', $this->username, $this->repo, 'pipelines', ...$parts);
     }
 }

--- a/src/Api/Repositories/Users/Pipelines.php
+++ b/src/Api/Repositories/Users/Pipelines.php
@@ -31,7 +31,7 @@ class Pipelines extends AbstractUsersApi
      */
     public function list(array $params = [])
     {
-        $path = $this->buildPipelinesPath() . '/';
+        $path = $this->buildPipelinesPath().'/';
 
         return $this->get($path, $params);
     }


### PR DESCRIPTION
The pipelines URL has a trailing slash:

> /2.0/repositories/{username}/{repo_slug}/pipelines/

https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/pipelines/