### PR TITLE
Patches: remove double $this->repo argument when building path

### DIFF
--- a/src/Api/Repositories/Users/Patches.php
+++ b/src/Api/Repositories/Users/Patches.php
@@ -46,6 +46,6 @@ class Patches extends AbstractUsersApi
      */
     protected function buildPatchesPath(string ...$parts)
     {
-        return static::buildPath('repositories', $this->username, $this->repo, $this->repo, 'patch', ...$parts);
+        return static::buildPath('repositories', $this->username, $this->repo, 'patch', ...$parts);
     }
 }


### PR DESCRIPTION
When using patches() method, the path contains repository_name too time.
This PR fix this issue #30