### PR TITLE
[3.2] Fixed the method used to list and get commits

### DIFF
--- a/src/Api/Repositories/Workspaces/Commits.php
+++ b/src/Api/Repositories/Workspaces/Commits.php
@@ -33,7 +33,7 @@ class Commits extends AbstractWorkspacesApi
     {
         $uri = $this->buildCommitsUri();
 
-        return $this->post($uri, $params);
+        return $this->get($uri, $params);
     }
 
     /**
@@ -48,7 +48,7 @@ class Commits extends AbstractWorkspacesApi
     {
         $uri = $this->buildCommitsUri($commit);
 
-        return $this->post($uri, $params);
+        return $this->get($uri, $params);
     }
 
     /**


### PR DESCRIPTION
Use `GET` instead of `POST` while retrieving commits.

The use of `POST` makes any parameter added to the `POST` body and converted to JSON.

As indicated into the Bitbucket API documentation, theses routes are using `GET` and not `POST` method.
https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/commits

By using `$this->get()`, all the parameters are now correctly added to the URI.