### PR TITLE
Increase maximum page length to 100, per API

### DIFF
--- a/src/ResultPager.php
+++ b/src/ResultPager.php
@@ -67,8 +67,8 @@ final class ResultPager implements ResultPagerInterface
      */
     public function __construct(Client $client, int $perPage = null)
     {
-        if (null !== $perPage && ($perPage < 1 || $perPage > 50)) {
-            throw new ValueError(\sprintf('%s::__construct(): Argument #2 ($perPage) must be between 1 and 50, or null', self::class));
+        if (null !== $perPage && ($perPage < 1 || $perPage > 100)) {
+            throw new ValueError(\sprintf('%s::__construct(): Argument #2 ($perPage) must be between 1 and 100, or null', self::class));
         }
 
         $this->client = $client;


### PR DESCRIPTION
Most page length limits are 100 per page, not 50 as currently hard-coded in `ResultPager`.

Perhaps a further improvement would be to add a `perPageMax()` method to `ApiInterface`, but a basic fix can be implemented without changing API.
