### PR TITLE
Add Support for Workspace Repository Permissions APIs

### DIFF
--- a/src/Api/Workspaces/Permissions/AbstractPermissionsApi.php
+++ b/src/Api/Workspaces/Permissions/AbstractPermissionsApi.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\Workspaces\Permissions;
+
+use Bitbucket\Api\Workspaces\AbstractWorkspacesApi;
+
+/**
+ * The abstract permissions API class.
+ *
+ * @author Patrick Barsallo <p.d.barsallo@gmail.com>
+ */
+abstract class AbstractPermissionsApi extends AbstractWorkspacesApi
+{
+}

--- a/src/Api/Workspaces/Permissions/Repositories.php
+++ b/src/Api/Workspaces/Permissions/Repositories.php
@@ -11,18 +11,16 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Bitbucket\Api\Workspaces;
+namespace Bitbucket\Api\Workspaces\Permissions;
 
-use Bitbucket\Api\Workspaces\Permissions\Repositories;
 use Bitbucket\HttpClient\Util\UriBuilder;
 
 /**
- * The permissions API class.
+ * The repositories API class.
  *
- * @author Graham Campbell <graham@alt-three.com>
  * @author Patrick Barsallo <p.d.barsallo@gmail.com>
  */
-class Permissions extends AbstractWorkspacesApi
+class Repositories extends AbstractPermissionsApi
 {
     /**
      * @param array $params
@@ -33,28 +31,35 @@ class Permissions extends AbstractWorkspacesApi
      */
     public function list(array $params = [])
     {
-        $uri = $this->buildPermissionsUri();
+        $uri = UriBuilder::appendSeparator($this->buildRepositoriesUri());
 
         return $this->get($uri, $params);
     }
 
     /**
-     * @return \Bitbucket\Api\Workspaces\Permissions\Repositories
+     * @param string $repo
+     * @param array  $params
+     *
+     * @throws \Http\Client\Exception
+     *
+     * @return array
      */
-    public function repositories()
+    public function show(string $repo, array $params = [])
     {
-        return new Repositories($this->getClient(), $this->workspace);
+        $uri = $this->buildRepositoriesUri($repo);
+
+        return $this->get($uri, $params);
     }
 
     /**
-     * Build the permissions URI from the given parts.
+     * Build the repositories URI from the given parts.
      *
      * @param string ...$parts
      *
      * @return string
      */
-    protected function buildPermissionsUri(string ...$parts)
+    protected function buildRepositoriesUri(string ...$parts)
     {
-        return UriBuilder::build('workspaces', $this->workspace, 'permissions', ...$parts);
+        return UriBuilder::build('workspaces', $this->workspace, 'permissions', 'repositories', ...$parts);
     }
 }


### PR DESCRIPTION
It appears that support for listing team repository permissions [was removed](https://github.com/BitbucketPHP/Client/compare/v2.1.5...v3.0.0#diff-71c5f24d2e2e660389af8afb6f9958cf1bcaf24dec9eb7788efef2f65e06ce3aL44) when the legacy teams API support was dropped (see src/Api/Teams/Permissions.php `listByRepository`). This PR aims to add the ability to list permissions for all repositories within a workspace, as well as by specific repository slug/UUID, according to the latest workspace [API documentation](https://developer.atlassian.com/bitbucket/api/2/reference/resource/workspaces/%7Bworkspace%7D/permissions/repositories).