### PR TITLE
Fix show single commit request url

### DIFF
--- a/src/Api/Repositories/Workspaces/Commits.php
+++ b/src/Api/Repositories/Workspaces/Commits.php
@@ -31,7 +31,7 @@ class Commits extends AbstractWorkspacesApi
      */
     public function list(array $params = [])
     {
-        $uri = $this->buildCommitsUri();
+        $uri = UriBuilder::build('repositories', $this->workspace, $this->repo, 'commits');
 
         return $this->get($uri, $params);
     }
@@ -46,20 +46,8 @@ class Commits extends AbstractWorkspacesApi
      */
     public function show(string $commit, array $params = [])
     {
-        $uri = $this->buildCommitsUri($commit);
+        $uri = UriBuilder::build('repositories', $this->workspace, $this->repo, 'commit', $commit);
 
         return $this->get($uri, $params);
-    }
-
-    /**
-     * Build the commits URI from the given parts.
-     *
-     * @param string ...$parts
-     *
-     * @return string
-     */
-    protected function buildCommitsUri(string ...$parts)
-    {
-        return UriBuilder::build('repositories', $this->workspace, $this->repo, 'commits', ...$parts);
     }
 }


### PR DESCRIPTION
The URL for showing a single commit is wrong causing the single commit request to actually do a list which is not as it should be 😄 

See: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commits/#api-repositories-workspace-repo-slug-commit-commit-get