### PR TITLE
[4.6] Slashes in file path used in Src and Downloads API classes are url-encoded

### DIFF
--- a/src/Api/Repositories/Workspaces/Downloads.php
+++ b/src/Api/Repositories/Workspaces/Downloads.php
@@ -65,7 +65,7 @@ class Downloads extends AbstractWorkspacesApi
      */
     public function download(string $filename, array $params = [])
     {
-        $uri = $this->buildDownloadsUri($filename);
+        $uri = $this->buildDownloadsUri(...\explode('/', $filename));
 
         return $this->getAsResponse($uri, $params, ['Accept' => '*/*'])->getBody();
     }
@@ -80,7 +80,7 @@ class Downloads extends AbstractWorkspacesApi
      */
     public function remove(string $filename, array $params = [])
     {
-        $uri = $this->buildDownloadsUri($filename);
+        $uri = $this->buildDownloadsUri(...\explode('/', $filename));
 
         return $this->delete($uri, $params);
     }

--- a/src/Api/Repositories/Workspaces/Src.php
+++ b/src/Api/Repositories/Workspaces/Src.php
@@ -94,7 +94,7 @@ class Src extends AbstractWorkspacesApi
      */
     public function show(string $commit, string $filepath, array $params = [])
     {
-        $uri = $this->buildSrcUri($commit, $filepath);
+        $uri = $this->buildSrcUri($commit, ...\explode('/', $filepath));
 
         if (!isset($params['format'])) {
             $params['format'] = 'meta';
@@ -114,7 +114,7 @@ class Src extends AbstractWorkspacesApi
      */
     public function download(string $commit, string $filepath, array $params = [])
     {
-        $uri = $this->buildSrcUri($commit, $filepath);
+        $uri = $this->buildSrcUri($commit, ...\explode('/', $filepath));
 
         return $this->getAsResponse($uri, $params, ['Accept' => '*/*'])->getBody();
     }

--- a/tests/ApiUrlTest.php
+++ b/tests/ApiUrlTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bitbucket\Tests;
+
+use Bitbucket\Client;
+use Bitbucket\HttpClient\Builder;
+use Http\Mock\Client as MockClient;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests API URLs constructed in Src and Downloads API classes.
+ */
+class ApiUrlTest extends TestCase
+{
+    protected MockClient $httpClient;
+    protected Client $client;
+
+    public function setUp(): void
+    {
+        $this->httpClient = new MockClient();
+        $this->client = new Client(new Builder($this->httpClient));
+    }
+
+    /**
+     * @covers \Bitbucket\Api\Repositories\Workspaces\Src::show
+     * @covers \Bitbucket\Api\Repositories\Workspaces\Src::buildSrcUri
+     *
+     * @dataProvider dataProvider
+     */
+    public function testWorkspaceSrcShowUri(string $fileName): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->src('my-project')
+            ->show('main', $fileName);
+
+        $this->assertSame(
+            "https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/src/main/$fileName?format=meta",
+            (string) $this->httpClient->getLastRequest()->getUri()
+        );
+    }
+
+    /**
+     * @covers \Bitbucket\Api\Repositories\Workspaces\Src::download
+     * @covers \Bitbucket\Api\Repositories\Workspaces\Src::buildSrcUri
+     *
+     * @dataProvider dataProvider
+     */
+    public function testWorkspaceSrcDownloadUri(string $fileName): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->src('my-project')
+            ->download('main', $fileName);
+
+        $this->assertSame(
+            "https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/src/main/$fileName",
+            (string) $this->httpClient->getLastRequest()->getUri()
+        );
+    }
+
+    /**
+     * @covers \Bitbucket\Api\Repositories\Workspaces\Downloads::download
+     * @covers \Bitbucket\Api\Repositories\Workspaces\Downloads::buildDownloadsUri
+     *
+     * @dataProvider dataProvider
+     */
+    public function testWorkspaceDownloadUri(string $fileName): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->downloads('my-project')
+            ->download($fileName);
+
+        $this->assertSame(
+            "https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/downloads/$fileName",
+            (string) $this->httpClient->getLastRequest()->getUri()
+        );
+    }
+
+    /**
+     * @covers \Bitbucket\Api\Repositories\Workspaces\Downloads::remove
+     * @covers \Bitbucket\Api\Repositories\Workspaces\Downloads::buildDownloadsUri
+     *
+     * @dataProvider dataProvider
+     */
+    public function testWorkspaceRemoveUri(string $fileName): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->downloads('my-project')
+            ->remove($fileName);
+
+        $this->assertSame(
+            "https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/downloads/$fileName",
+            (string) $this->httpClient->getLastRequest()->getUri()
+        );
+    }
+
+    public static function dataProvider(): array
+    {
+        return [
+            'File in root' => ['README.md'],
+            'File in subdirectory' => ['docs/contributing/CODE_OF_CONDUCT.md'],
+        ];
+    }
+}


### PR DESCRIPTION
Slashes in file path used in Src and Downloads API classes are url-encoded, which makes it impossible to get metadata or get the content of files from a repository unless the file is in the project root.

For example, in case of `\Bitbucket\Api\Repositories\Workspaces\Src::download()`, if I want to download a file from my project's subfolder: 
```php
$this->client->repositories()
    ->workspaces('my-workspace')
    ->src('my-project')
    ->download('main', 'docs/foo/BAR.md');
```

...then I expect that the client fetches the data from the URI string `https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/src/main/docs/foo/BAR.md`,

but the URI string will be `https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/src/main/docs%2Ffoo%2FBAR.md`, which will obviously fail to return the file's content (and throws an API error instead).

Methods affected:
 - `\Bitbucket\Api\Repositories\Workspaces\Src::show()`
 - `\Bitbucket\Api\Repositories\Workspaces\Src::download()`
 - `\Bitbucket\Api\Repositories\Workspaces\Downloads::download()`
 - `\Bitbucket\Api\Repositories\Workspaces\Downloads::remove()`

Added a new test which hopefully describes my issue more clearly.

Asking for a review, and last but not least, thank you for this Bitbucket Client!