### PR TITLE
Avoid deprecation warnings on PHP 8.4

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -99,7 +99,7 @@ class Client
      *
      * @return void
      */
-    public function __construct(Builder $httpClientBuilder = null)
+    public function __construct(?Builder $httpClientBuilder = null)
     {
         $this->httpClientBuilder = $builder = $httpClientBuilder ?? new Builder();
         $this->responseHistory = new History();
@@ -207,7 +207,7 @@ class Client
      *
      * @return void
      */
-    public function authenticate(string $method, string $token, string $password = null): void
+    public function authenticate(string $method, string $token, ?string $password = null): void
     {
         $this->getHttpClientBuilder()->removePlugin(Authentication::class);
         $this->getHttpClientBuilder()->addPlugin(new Authentication($method, $token, $password));

--- a/src/HttpClient/Builder.php
+++ b/src/HttpClient/Builder.php
@@ -90,9 +90,9 @@ final class Builder
      * @return void
      */
     public function __construct(
-        ClientInterface $httpClient = null,
-        RequestFactoryInterface $requestFactory = null,
-        StreamFactoryInterface $streamFactory = null
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null
     ) {
         $this->httpClient = $httpClient ?? Psr18ClientDiscovery::find();
         $this->requestFactory = $requestFactory ?? Psr17FactoryDiscovery::findRequestFactory();

--- a/src/HttpClient/Plugin/Authentication.php
+++ b/src/HttpClient/Plugin/Authentication.php
@@ -46,7 +46,7 @@ final class Authentication implements Plugin
      *
      * @return void
      */
-    public function __construct(string $method, string $token, string $password = null)
+    public function __construct(string $method, string $token, ?string $password = null)
     {
         $this->header = self::buildAuthorizationHeader($method, $token, $password);
     }
@@ -78,7 +78,7 @@ final class Authentication implements Plugin
      *
      * @return string
      */
-    private static function buildAuthorizationHeader(string $method, string $token, string $password = null): string
+    private static function buildAuthorizationHeader(string $method, string $token, ?string $password = null): string
     {
         switch ($method) {
             case Client::AUTH_HTTP_PASSWORD:

--- a/src/ResultPager.php
+++ b/src/ResultPager.php
@@ -65,7 +65,7 @@ final class ResultPager implements ResultPagerInterface
      *
      * @return void
      */
-    public function __construct(Client $client, int $perPage = null)
+    public function __construct(Client $client, ?int $perPage = null)
     {
         if (null !== $perPage && ($perPage < 1 || $perPage > 50)) {
             throw new ValueError(\sprintf('%s::__construct(): Argument #2 ($perPage) must be between 1 and 50, or null', self::class));


### PR DESCRIPTION
These are the warnings I am getting, which I am hoping to fix with this PR

```
Deprecated: Bitbucket\Client::__construct(): Implicitly marking parameter $httpClientBuilder as nullable is deprecated, the explicit nullable type must be used instead in phar:///app/runner/vendor/bitbucket/client/src/Client.php on line 102

Deprecated: Bitbucket\Client::authenticate(): Implicitly marking parameter $password as nullable is deprecated, the explicit nullable type must be used instead in phar:///app/runner/vendor/bitbucket/client/src/Client.php on line 210

Deprecated: Bitbucket\HttpClient\Builder::__construct(): Implicitly marking parameter $httpClient as nullable is deprecated, the explicit nullable type must be used instead in phar:///app/runner/vendor/bitbucket/client/src/HttpClient/Builder.php on line 92

Deprecated: Bitbucket\HttpClient\Builder::__construct(): Implicitly marking parameter $requestFactory as nullable is deprecated, the explicit nullable type must be used instead in phar:///app/runner/vendor/bitbucket/client/src/HttpClient/Builder.php on line 92

Deprecated: Bitbucket\HttpClient\Builder::__construct(): Implicitly marking parameter $streamFactory as nullable is deprecated, the explicit nullable type must be used instead in phar:///app/runner/vendor/bitbucket/client/src/HttpClient/Builder.php on line 92

Deprecated: Bitbucket\HttpClient\Plugin\Authentication::__construct(): Implicitly marking parameter $password as nullable is deprecated, the explicit nullable type must be used instead in phar:///app/runner/vendor/bitbucket/client/src/HttpClient/Plugin/Authentication.php on line 49

Deprecated: Bitbucket\HttpClient\Plugin\Authentication::buildAuthorizationHeader(): Implicitly marking parameter $password as nullable is deprecated, the explicit nullable type must be used instead in phar:///app/runner/vendor/bitbucket/client/src/HttpClient/Plugin/Authentication.php on line 81

Deprecated: Bitbucket\ResultPager::__construct(): Implicitly marking parameter $perPage as nullable is deprecated, the explicit nullable type must be used instead in phar:///app/runner/vendor/bitbucket/client/src/ResultPager.php on line 68

```