### PR TITLE
Fix current user workspaces endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGE LOG
 ## V5.1 (UPCOMING)
 
 * Add PHP 8.5 support
+* Fixed the current user workspaces endpoint
 
 
 ## V5.0 (23/02/2025)

--- a/src/Api/CurrentUser.php
+++ b/src/Api/CurrentUser.php
@@ -87,7 +87,7 @@ class CurrentUser extends AbstractApi
      */
     public function listWorkspaces(array $params = []): array
     {
-        $uri = UriBuilder::build('workspaces');
+        $uri = $this->buildCurrentUserUri('workspaces');
 
         return $this->get($uri, $params);
     }


### PR DESCRIPTION
## Summary
- Update `CurrentUser::listWorkspaces()` to call Bitbucket's supported `/user/workspaces` endpoint.
- Avoid the deprecated/removed cross-workspace `/workspaces` endpoint.
- Update the V5.1 changelog.

## Testing
- `php -l src/Api/CurrentUser.php`
- Existing PHPUnit/PHPStan/Psalm binaries were not available in this checkout (`vendor-bin/*/vendor/bin/*` missing).