### PR TITLE
Add current user workspace permission endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGE LOG
 
 * Add PHP 8.5 support
 * Fixed the current user workspaces endpoint
+* Added the current user workspace permission endpoint
 
 
 ## V5.0 (23/02/2025)

--- a/src/Api/CurrentUser.php
+++ b/src/Api/CurrentUser.php
@@ -74,10 +74,22 @@ class CurrentUser extends AbstractApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Use showWorkspacePermission() instead.
      */
     public function listWorkspacePermissions(array $params = []): array
     {
         $uri = $this->buildCurrentUserUri('permissions', 'workspaces');
+
+        return $this->get($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function showWorkspacePermission(string $workspace, array $params = []): array
+    {
+        $uri = $this->buildCurrentUserUri('workspaces', $workspace, 'permission');
 
         return $this->get($uri, $params);
     }

--- a/src/Api/CurrentUser.php
+++ b/src/Api/CurrentUser.php
@@ -75,7 +75,7 @@ class CurrentUser extends AbstractApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Use showWorkspacePermission() instead.
+     * @deprecated use showWorkspacePermission() instead
      */
     public function listWorkspacePermissions(array $params = []): array
     {


### PR DESCRIPTION
## Summary
- Add `CurrentUser::showWorkspacePermission()` for Bitbucket's supported `/user/workspaces/{workspace}/permission` endpoint.
- Deprecate `CurrentUser::listWorkspacePermissions()` in favor of the workspace-scoped endpoint.
- Update the V5.1 changelog.

## Testing
- `php -l src/Api/CurrentUser.php`
- No tests added to stay consistent with the existing test style for this API surface.
- Existing PHPUnit/PHPStan/Psalm binaries are not installed in this checkout (`vendor-bin/*/vendor/bin/*` missing).