### PR TITLE
Add current user repository permissions endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGE LOG
 * Add PHP 8.5 support
 * Fixed the current user workspaces endpoint
 * Added the current user workspace permission endpoint
+* Added the current user repository permissions endpoint for a workspace
 
 
 ## V5.0 (23/02/2025)

--- a/src/Api/CurrentUser.php
+++ b/src/Api/CurrentUser.php
@@ -54,10 +54,22 @@ class CurrentUser extends AbstractApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated use listRepositoryPermissionsForWorkspace() instead
      */
     public function listRepositoryPermissions(array $params = []): array
     {
         $uri = $this->buildCurrentUserUri('permissions', 'repositories');
+
+        return $this->get($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function listRepositoryPermissionsForWorkspace(string $workspace, array $params = []): array
+    {
+        $uri = $this->buildCurrentUserUri('workspaces', $workspace, 'permissions', 'repositories');
 
         return $this->get($uri, $params);
     }


### PR DESCRIPTION
## Summary
- Add `CurrentUser::listRepositoryPermissionsForWorkspace()` for Bitbucket's supported `/user/workspaces/{workspace}/permissions/repositories` endpoint.
- Deprecate `CurrentUser::listRepositoryPermissions()` in favor of the workspace-scoped endpoint.
- Update the V5.1 changelog.

## Testing
- `php -l src/Api/CurrentUser.php`
- No tests added to stay consistent with the existing test style for this API surface.
- Existing PHPUnit/PHPStan/Psalm binaries are not installed in this checkout (`vendor-bin/*/vendor/bin/*` missing).