### PR TITLE
Add current user workspaces API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGE LOG
 
 * Add PHP 8.5 support
 * Fixed the current user workspaces endpoint
-* Added the current user workspace permission endpoint
+* Added the current user workspaces API
 
 
 ## V5.0 (23/02/2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGE LOG
 * Add PHP 8.5 support
 * Fixed the current user workspaces endpoint
 * Added the current user workspaces API
+* Deprecated current user workspaces pass-through methods
 
 
 ## V5.0 (23/02/2025)

--- a/src/Api/CurrentUser.php
+++ b/src/Api/CurrentUser.php
@@ -94,6 +94,8 @@ class CurrentUser extends AbstractApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated use workspaces()->list() instead
      */
     public function listWorkspaces(array $params = []): array
     {

--- a/src/Api/CurrentUser.php
+++ b/src/Api/CurrentUser.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Bitbucket\Api;
 
+use Bitbucket\Api\CurrentUser\Workspaces as CurrentUserWorkspaces;
 use Bitbucket\HttpClient\Util\UriBuilder;
 
 /**
@@ -54,6 +55,8 @@ class CurrentUser extends AbstractApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated use workspaces()->listRepositoryPermissions() instead
      */
     public function listRepositoryPermissions(array $params = []): array
     {
@@ -75,7 +78,7 @@ class CurrentUser extends AbstractApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated use showWorkspacePermission() instead
+     * @deprecated use workspaces()->showPermission() instead
      */
     public function listWorkspacePermissions(array $params = []): array
     {
@@ -84,14 +87,9 @@ class CurrentUser extends AbstractApi
         return $this->get($uri, $params);
     }
 
-    /**
-     * @throws \Http\Client\Exception
-     */
-    public function showWorkspacePermission(string $workspace, array $params = []): array
+    public function workspaces(): CurrentUserWorkspaces
     {
-        $uri = $this->buildCurrentUserUri('workspaces', $workspace, 'permission');
-
-        return $this->get($uri, $params);
+        return new CurrentUserWorkspaces($this->getClient());
     }
 
     /**
@@ -99,9 +97,7 @@ class CurrentUser extends AbstractApi
      */
     public function listWorkspaces(array $params = []): array
     {
-        $uri = $this->buildCurrentUserUri('workspaces');
-
-        return $this->get($uri, $params);
+        return $this->workspaces()->list($params);
     }
 
     /**

--- a/src/Api/CurrentUser.php
+++ b/src/Api/CurrentUser.php
@@ -56,7 +56,7 @@ class CurrentUser extends AbstractApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated use workspaces()->listRepositoryPermissions() instead
+     * @deprecated use workspaces()->permissions($workspace)->repositories()->list() instead
      */
     public function listRepositoryPermissions(array $params = []): array
     {
@@ -78,7 +78,7 @@ class CurrentUser extends AbstractApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated use workspaces()->showPermission() instead
+     * @deprecated use workspaces()->permissions($workspace)->show() instead
      */
     public function listWorkspacePermissions(array $params = []): array
     {

--- a/src/Api/CurrentUser/AbstractCurrentUserApi.php
+++ b/src/Api/CurrentUser/AbstractCurrentUserApi.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\CurrentUser;
+
+use Bitbucket\Api\AbstractApi;
+
+/**
+ * The abstract current user API class.
+ *
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+abstract class AbstractCurrentUserApi extends AbstractApi
+{
+}

--- a/src/Api/CurrentUser/Workspaces.php
+++ b/src/Api/CurrentUser/Workspaces.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\CurrentUser;
+
+use Bitbucket\HttpClient\Util\UriBuilder;
+
+/**
+ * The workspaces API class.
+ *
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+class Workspaces extends AbstractCurrentUserApi
+{
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function list(array $params = []): array
+    {
+        $uri = $this->buildWorkspacesUri();
+
+        return $this->get($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function showPermission(string $workspace, array $params = []): array
+    {
+        $uri = $this->buildWorkspacesUri($workspace, 'permission');
+
+        return $this->get($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function listRepositoryPermissions(string $workspace, array $params = []): array
+    {
+        $uri = $this->buildWorkspacesUri($workspace, 'permissions', 'repositories');
+
+        return $this->get($uri, $params);
+    }
+
+    /**
+     * Build the workspaces URI from the given parts.
+     */
+    protected function buildWorkspacesUri(string ...$parts): string
+    {
+        return UriBuilder::build('user', 'workspaces', ...$parts);
+    }
+}

--- a/src/Api/CurrentUser/Workspaces/AbstractWorkspacesApi.php
+++ b/src/Api/CurrentUser/Workspaces/AbstractWorkspacesApi.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\CurrentUser\Workspaces;
+
+use Bitbucket\Api\CurrentUser\AbstractCurrentUserApi;
+use Bitbucket\Client;
+
+/**
+ * The abstract workspaces API class.
+ *
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+abstract class AbstractWorkspacesApi extends AbstractCurrentUserApi
+{
+    protected readonly string $workspace;
+
+    public function __construct(Client $client, string $workspace)
+    {
+        parent::__construct($client);
+        $this->workspace = $workspace;
+    }
+}

--- a/src/Api/CurrentUser/Workspaces/Permissions.php
+++ b/src/Api/CurrentUser/Workspaces/Permissions.php
@@ -11,31 +11,31 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Bitbucket\Api\CurrentUser;
+namespace Bitbucket\Api\CurrentUser\Workspaces;
 
-use Bitbucket\Api\CurrentUser\Workspaces\Permissions;
+use Bitbucket\Api\CurrentUser\Workspaces\Permissions\Repositories;
 use Bitbucket\HttpClient\Util\UriBuilder;
 
 /**
- * The workspaces API class.
+ * The permissions API class.
  *
  * @author Graham Campbell <hello@gjcampbell.co.uk>
  */
-class Workspaces extends AbstractCurrentUserApi
+class Permissions extends AbstractWorkspacesApi
 {
     /**
      * @throws \Http\Client\Exception
      */
-    public function list(array $params = []): array
+    public function show(array $params = []): array
     {
-        $uri = $this->buildWorkspacesUri();
+        $uri = $this->buildWorkspacesUri('permission');
 
         return $this->get($uri, $params);
     }
 
-    public function permissions(string $workspace): Permissions
+    public function repositories(): Repositories
     {
-        return new Permissions($this->getClient(), $workspace);
+        return new Repositories($this->getClient(), $this->workspace);
     }
 
     /**
@@ -43,6 +43,6 @@ class Workspaces extends AbstractCurrentUserApi
      */
     protected function buildWorkspacesUri(string ...$parts): string
     {
-        return UriBuilder::build('user', 'workspaces', ...$parts);
+        return UriBuilder::build('user', 'workspaces', $this->workspace, ...$parts);
     }
 }

--- a/src/Api/CurrentUser/Workspaces/Permissions/AbstractPermissionsApi.php
+++ b/src/Api/CurrentUser/Workspaces/Permissions/AbstractPermissionsApi.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\CurrentUser\Workspaces\Permissions;
+
+use Bitbucket\Api\CurrentUser\Workspaces\AbstractWorkspacesApi;
+
+/**
+ * The abstract permissions API class.
+ *
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+abstract class AbstractPermissionsApi extends AbstractWorkspacesApi
+{
+}

--- a/src/Api/CurrentUser/Workspaces/Permissions/Repositories.php
+++ b/src/Api/CurrentUser/Workspaces/Permissions/Repositories.php
@@ -11,38 +11,32 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Bitbucket\Api\CurrentUser;
+namespace Bitbucket\Api\CurrentUser\Workspaces\Permissions;
 
-use Bitbucket\Api\CurrentUser\Workspaces\Permissions;
 use Bitbucket\HttpClient\Util\UriBuilder;
 
 /**
- * The workspaces API class.
+ * The repositories API class.
  *
  * @author Graham Campbell <hello@gjcampbell.co.uk>
  */
-class Workspaces extends AbstractCurrentUserApi
+class Repositories extends AbstractPermissionsApi
 {
     /**
      * @throws \Http\Client\Exception
      */
     public function list(array $params = []): array
     {
-        $uri = $this->buildWorkspacesUri();
+        $uri = UriBuilder::appendSeparator($this->buildRepositoriesUri());
 
         return $this->get($uri, $params);
     }
 
-    public function permissions(string $workspace): Permissions
-    {
-        return new Permissions($this->getClient(), $workspace);
-    }
-
     /**
-     * Build the workspaces URI from the given parts.
+     * Build the repositories URI from the given parts.
      */
-    protected function buildWorkspacesUri(string ...$parts): string
+    protected function buildRepositoriesUri(string ...$parts): string
     {
-        return UriBuilder::build('user', 'workspaces', ...$parts);
+        return UriBuilder::build('user', 'workspaces', $this->workspace, 'permissions', 'repositories', ...$parts);
     }
 }


### PR DESCRIPTION
## Summary
- Add `CurrentUser::workspaces()` with `list()` for the supported current-user workspace listing endpoint.
- Add nested `currentUser()->workspaces()->permissions($workspace)` APIs matching the existing `Workspaces\Permissions` model.
- Add `permissions($workspace)->show()` for `/user/workspaces/{workspace}/permission`.
- Add `permissions($workspace)->repositories()->list()` for `/user/workspaces/{workspace}/permissions/repositories`.
- Keep `CurrentUser::listWorkspaces()` as a delegating convenience method, but deprecate it in favor of `currentUser()->workspaces()->list()`.
- Remove the unreleased flat `CurrentUser::showWorkspacePermission()` method in favor of the nested API.
- Deprecate the old cross-workspace permissions methods and update the V5.1 changelog.

## Notes
- Replaces the closed #98 with an API shape that follows the client's nested resource model.

## Testing
- `php -l src/Api/CurrentUser.php`
- `php -l src/Api/CurrentUser/AbstractCurrentUserApi.php`
- `php -l src/Api/CurrentUser/Workspaces.php`
- `php -l src/Api/CurrentUser/Workspaces/AbstractWorkspacesApi.php`
- `php -l src/Api/CurrentUser/Workspaces/Permissions.php`
- `php -l src/Api/CurrentUser/Workspaces/Permissions/AbstractPermissionsApi.php`
- `php -l src/Api/CurrentUser/Workspaces/Permissions/Repositories.php`
- No tests added to stay consistent with the existing test style for this API surface.
- Existing PHPUnit/PHPStan/Psalm binaries are not installed in this checkout (`vendor-bin/*/vendor/bin/*` missing).