### PR TITLE
Add workspace pull requests endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGE LOG
 * Fixed the current user workspaces endpoint
 * Added the current user workspaces API
 * Deprecated current user workspaces pass-through methods
+* Added the workspace pull requests endpoint for a selected user
 
 
 ## V5.0 (23/02/2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ CHANGE LOG
 * Add PHP 8.5 support
 * Fixed the current user workspaces endpoint
 * Added the current user workspaces API
-* Deprecated current user workspaces pass-through methods
 * Added the workspace pull requests endpoint for a selected user
+* Deprecated current user workspaces pass-through methods
+* Deprecated the top-level pull requests pass-through method
 
 
 ## V5.0 (23/02/2025)

--- a/src/Api/Workspaces.php
+++ b/src/Api/Workspaces.php
@@ -18,6 +18,7 @@ use Bitbucket\Api\Workspaces\Members;
 use Bitbucket\Api\Workspaces\Permissions;
 use Bitbucket\Api\Workspaces\PipelinesConfig;
 use Bitbucket\Api\Workspaces\Projects;
+use Bitbucket\Api\Workspaces\PullRequests as WorkspacesPullRequests;
 use Bitbucket\Client;
 use Bitbucket\HttpClient\Util\UriBuilder;
 
@@ -79,6 +80,11 @@ class Workspaces extends AbstractApi
     public function projects(): Projects
     {
         return new Projects($this->getClient(), $this->workspace);
+    }
+
+    public function pullRequests(): WorkspacesPullRequests
+    {
+        return new WorkspacesPullRequests($this->getClient(), $this->workspace);
     }
 
     /**

--- a/src/Api/Workspaces/PullRequests.php
+++ b/src/Api/Workspaces/PullRequests.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Bitbucket\Api;
+namespace Bitbucket\Api\Workspaces;
 
 use Bitbucket\HttpClient\Util\UriBuilder;
 
@@ -20,16 +20,14 @@ use Bitbucket\HttpClient\Util\UriBuilder;
  *
  * @author Graham Campbell <hello@gjcampbell.co.uk>
  */
-class PullRequests extends AbstractApi
+class PullRequests extends AbstractWorkspacesApi
 {
     /**
      * @throws \Http\Client\Exception
-     *
-     * @deprecated use workspaces($workspace)->pullRequests()->list() instead
      */
-    public function list(string $username, array $params = []): array
+    public function list(string $selectedUser, array $params = []): array
     {
-        $uri = $this->buildPullRequestsUri($username);
+        $uri = $this->buildPullRequestsUri($selectedUser);
 
         return $this->get($uri, $params);
     }
@@ -39,6 +37,6 @@ class PullRequests extends AbstractApi
      */
     protected function buildPullRequestsUri(string ...$parts): string
     {
-        return UriBuilder::build('pullrequests', ...$parts);
+        return UriBuilder::build('workspaces', $this->workspace, 'pullrequests', ...$parts);
     }
 }


### PR DESCRIPTION
## Summary
- Add `workspaces($workspace)->pullRequests()->list($selectedUser)` for Bitbucket's supported `/workspaces/{workspace}/pullrequests/{selected_user}` endpoint.
- Deprecate the old top-level `PullRequests::list()` pass-through method.
- Update the V5.1 changelog, keeping deprecation entries grouped at the end.

## Notes
- Supersedes the API addition proposed in #90 with the current 5.1 branch and repository style.

## Testing
- `php -l src/Api/Workspaces.php`
- `php -l src/Api/Workspaces/PullRequests.php`
- `php -l src/Api/PullRequests.php`
- No tests added to stay consistent with the existing test style for this API surface.
- Existing PHPUnit/PHPStan/Psalm binaries are not installed in this checkout (`vendor-bin/*/vendor/bin/*` missing).