### PR TITLE
Deprecate repository listing endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGE LOG
 * Added the workspace pull requests endpoint for a selected user
 * Deprecated current user workspaces pass-through methods
 * Deprecated the top-level pull requests pass-through method
+* Deprecated repository listing pass-through methods
 
 
 ## V5.0 (23/02/2025)

--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -25,6 +25,8 @@ class Repositories extends AbstractApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated use workspaces($workspace)->list() instead
      */
     public function list(array $params = []): array
     {

--- a/src/Api/Users/Repositories.php
+++ b/src/Api/Users/Repositories.php
@@ -24,6 +24,8 @@ class Repositories extends AbstractUsersApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated use repositories()->workspaces($workspace)->list() instead
      */
     public function list(array $params = []): array
     {


### PR DESCRIPTION
## Summary
- Deprecate the top-level `Repositories::list()` pass-through method in favor of `repositories()->workspaces($workspace)->list()`.
- Deprecate `Users\Repositories::list()` in favor of workspace-scoped repository listing.
- Update the V5.1 changelog, keeping deprecation entries grouped at the end.

## Testing
- `php -l src/Api/Repositories.php`
- `php -l src/Api/Users/Repositories.php`
- No tests added to stay consistent with the existing test style for this API surface.
- Existing PHPUnit/PHPStan/Psalm binaries are not installed in this checkout (`vendor-bin/*/vendor/bin/*` missing).