### PR TITLE
Deprecate global snippets listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGE LOG
 * Deprecated current user workspaces pass-through methods
 * Deprecated the top-level pull requests pass-through method
 * Deprecated repository listing pass-through methods
+* Deprecated the global snippets listing pass-through method
 
 
 ## V5.0 (23/02/2025)

--- a/src/Api/Snippets.php
+++ b/src/Api/Snippets.php
@@ -28,6 +28,8 @@ class Snippets extends AbstractApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated use workspaces($workspace)->list() instead
      */
     public function list(array $params = []): array
     {


### PR DESCRIPTION
## Summary
- Deprecate the global `Snippets::list()` pass-through method in favor of `snippets()->workspaces($workspace)->list()`.
- Update the V5.1 changelog, keeping deprecation entries grouped at the end.

## Testing
- `php -l src/Api/Snippets.php`
- No tests added to stay consistent with the existing test style for this API surface.
- Existing PHPUnit/PHPStan/Psalm binaries are not installed in this checkout (`vendor-bin/*/vendor/bin/*` missing).