### PR TITLE
Deprecate snippet watchers listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGE LOG
 * Deprecated the top-level pull requests pass-through method
 * Deprecated repository listing pass-through methods
 * Deprecated the global snippets listing pass-through method
+* Deprecated snippet watchers listing methods
 
 
 ## V5.0 (23/02/2025)

--- a/src/Api/Snippets/Workspaces.php
+++ b/src/Api/Snippets/Workspaces.php
@@ -130,7 +130,7 @@ class Workspaces extends AbstractSnippetsApi
     }
 
     /**
-     * @deprecated Bitbucket has deprecated listing snippet watchers.
+     * @deprecated bitbucket has deprecated listing snippet watchers
      */
     public function watchers(string $snippet): Watchers
     {

--- a/src/Api/Snippets/Workspaces.php
+++ b/src/Api/Snippets/Workspaces.php
@@ -129,6 +129,9 @@ class Workspaces extends AbstractSnippetsApi
         return new Patches($this->getClient(), $this->workspace, $snippet);
     }
 
+    /**
+     * @deprecated Bitbucket has deprecated listing snippet watchers.
+     */
     public function watchers(string $snippet): Watchers
     {
         return new Watchers($this->getClient(), $this->workspace, $snippet);

--- a/src/Api/Snippets/Workspaces/Watchers.php
+++ b/src/Api/Snippets/Workspaces/Watchers.php
@@ -24,6 +24,8 @@ class Watchers extends AbstractWorkspacesApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated listing snippet watchers.
      */
     public function list(array $params = []): array
     {

--- a/src/Api/Snippets/Workspaces/Watchers.php
+++ b/src/Api/Snippets/Workspaces/Watchers.php
@@ -25,7 +25,7 @@ class Watchers extends AbstractWorkspacesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated listing snippet watchers.
+     * @deprecated bitbucket has deprecated listing snippet watchers
      */
     public function list(array $params = []): array
     {


### PR DESCRIPTION
## Summary
- Deprecate `snippets()->workspaces($workspace)->watchers($snippet)`.
- Deprecate `Snippets\Workspaces\Watchers::list()`.
- Update the V5.1 changelog, keeping deprecation entries grouped at the end.

## Testing
- `php -l src/Api/Snippets/Workspaces.php`
- `php -l src/Api/Snippets/Workspaces/Watchers.php`
- No tests added to stay consistent with the existing test style for this API surface.
- Existing PHPUnit/PHPStan/Psalm binaries are not installed in this checkout (`vendor-bin/*/vendor/bin/*` missing).