### PR TITLE
Deprecate workspace code search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGE LOG
 * Deprecated repository listing pass-through methods
 * Deprecated the global snippets listing pass-through method
 * Deprecated snippet watchers listing methods
+* Deprecated workspace code search
 
 
 ## V5.0 (23/02/2025)

--- a/src/Api/Workspaces.php
+++ b/src/Api/Workspaces.php
@@ -50,7 +50,7 @@ class Workspaces extends AbstractApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated legacy code search.
+     * @deprecated bitbucket has deprecated legacy code search
      */
     public function codeSearch(array $params = []): array
     {

--- a/src/Api/Workspaces.php
+++ b/src/Api/Workspaces.php
@@ -49,6 +49,8 @@ class Workspaces extends AbstractApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated legacy code search.
      */
     public function codeSearch(array $params = []): array
     {


### PR DESCRIPTION
## Summary
- Deprecate `workspaces($workspace)->codeSearch()` because Bitbucket has deprecated legacy code search.
- Update the V5.1 changelog, keeping deprecation entries grouped at the end.

## Testing
- `php -l src/Api/Workspaces.php`
- No tests added to stay consistent with the existing test style for this API surface.
- Existing PHPUnit/PHPStan/Psalm binaries are not installed in this checkout (`vendor-bin/*/vendor/bin/*` missing).