### PR TITLE
Deprecate addon linker APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGE LOG
 * Deprecated the global snippets listing pass-through method
 * Deprecated snippet watchers listing methods
 * Deprecated workspace code search
+* Deprecated addon linker methods
 
 
 ## V5.0 (23/02/2025)

--- a/src/Api/Addon.php
+++ b/src/Api/Addon.php
@@ -44,6 +44,9 @@ class Addon extends AbstractApi
         return $this->delete($uri, $params);
     }
 
+    /**
+     * @deprecated Bitbucket has deprecated addon linker APIs.
+     */
     public function linkers(): Linkers
     {
         return new Linkers($this->getClient());

--- a/src/Api/Addon.php
+++ b/src/Api/Addon.php
@@ -45,7 +45,7 @@ class Addon extends AbstractApi
     }
 
     /**
-     * @deprecated Bitbucket has deprecated addon linker APIs.
+     * @deprecated bitbucket has deprecated addon linker APIs
      */
     public function linkers(): Linkers
     {

--- a/src/Api/Addon/Linkers.php
+++ b/src/Api/Addon/Linkers.php
@@ -26,7 +26,7 @@ class Linkers extends AbstractAddonApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated addon linker APIs.
+     * @deprecated bitbucket has deprecated addon linker APIs
      */
     public function list(array $params = []): array
     {
@@ -38,7 +38,7 @@ class Linkers extends AbstractAddonApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated addon linker APIs.
+     * @deprecated bitbucket has deprecated addon linker APIs
      */
     public function show(string $linker, array $params = []): array
     {
@@ -48,7 +48,7 @@ class Linkers extends AbstractAddonApi
     }
 
     /**
-     * @deprecated Bitbucket has deprecated addon linker APIs.
+     * @deprecated bitbucket has deprecated addon linker APIs
      */
     public function values(string $linker): Values
     {

--- a/src/Api/Addon/Linkers.php
+++ b/src/Api/Addon/Linkers.php
@@ -25,6 +25,8 @@ class Linkers extends AbstractAddonApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated addon linker APIs.
      */
     public function list(array $params = []): array
     {
@@ -35,6 +37,8 @@ class Linkers extends AbstractAddonApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated addon linker APIs.
      */
     public function show(string $linker, array $params = []): array
     {
@@ -43,6 +47,9 @@ class Linkers extends AbstractAddonApi
         return $this->get($uri, $params);
     }
 
+    /**
+     * @deprecated Bitbucket has deprecated addon linker APIs.
+     */
     public function values(string $linker): Values
     {
         return new Values($this->getClient(), $linker);

--- a/src/Api/Addon/Linkers/Values.php
+++ b/src/Api/Addon/Linkers/Values.php
@@ -24,6 +24,8 @@ class Values extends AbstractLinkersApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated addon linker APIs.
      */
     public function list(array $params = []): array
     {
@@ -34,6 +36,8 @@ class Values extends AbstractLinkersApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated addon linker APIs.
      */
     public function create(array $params = []): array
     {
@@ -44,6 +48,8 @@ class Values extends AbstractLinkersApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated addon linker APIs.
      */
     public function show(string $id, array $params = []): array
     {
@@ -54,6 +60,8 @@ class Values extends AbstractLinkersApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated addon linker APIs.
      */
     public function update(string $id, array $params = []): array
     {
@@ -64,6 +72,8 @@ class Values extends AbstractLinkersApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated addon linker APIs.
      */
     public function remove(string $id, array $params = []): array
     {

--- a/src/Api/Addon/Linkers/Values.php
+++ b/src/Api/Addon/Linkers/Values.php
@@ -25,7 +25,7 @@ class Values extends AbstractLinkersApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated addon linker APIs.
+     * @deprecated bitbucket has deprecated addon linker APIs
      */
     public function list(array $params = []): array
     {
@@ -37,7 +37,7 @@ class Values extends AbstractLinkersApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated addon linker APIs.
+     * @deprecated bitbucket has deprecated addon linker APIs
      */
     public function create(array $params = []): array
     {
@@ -49,7 +49,7 @@ class Values extends AbstractLinkersApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated addon linker APIs.
+     * @deprecated bitbucket has deprecated addon linker APIs
      */
     public function show(string $id, array $params = []): array
     {
@@ -61,7 +61,7 @@ class Values extends AbstractLinkersApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated addon linker APIs.
+     * @deprecated bitbucket has deprecated addon linker APIs
      */
     public function update(string $id, array $params = []): array
     {
@@ -73,7 +73,7 @@ class Values extends AbstractLinkersApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated addon linker APIs.
+     * @deprecated bitbucket has deprecated addon linker APIs
      */
     public function remove(string $id, array $params = []): array
     {


### PR DESCRIPTION
## Summary
- Deprecate `addon()->linkers()` and the addon linker API methods.
- Update the V5.1 changelog, keeping deprecation entries grouped at the end.

## Testing
- `php -l src/Api/Addon.php`
- `php -l src/Api/Addon/Linkers.php`
- `php -l src/Api/Addon/Linkers/Values.php`
- No tests added to stay consistent with the existing test style for this API surface.
- Existing PHPUnit/PHPStan/Psalm binaries are not installed in this checkout (`vendor-bin/*/vendor/bin/*` missing).