### PR TITLE
Deprecate native issue tracker APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGE LOG
 * Deprecated snippet watchers listing methods
 * Deprecated workspace code search
 * Deprecated addon linker methods
+* Deprecated native issue tracker methods
 
 
 ## V5.0 (23/02/2025)

--- a/src/Api/Repositories/Workspaces.php
+++ b/src/Api/Repositories/Workspaces.php
@@ -120,7 +120,7 @@ class Workspaces extends AbstractRepositoriesApi
     }
 
     /**
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function components(string $repo): Components
     {
@@ -178,7 +178,7 @@ class Workspaces extends AbstractRepositoriesApi
     }
 
     /**
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function issues(string $repo): Issues
     {
@@ -191,7 +191,7 @@ class Workspaces extends AbstractRepositoriesApi
     }
 
     /**
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function milestones(string $repo): Milestones
     {
@@ -234,7 +234,7 @@ class Workspaces extends AbstractRepositoriesApi
     }
 
     /**
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function versions(string $repo): Versions
     {

--- a/src/Api/Repositories/Workspaces.php
+++ b/src/Api/Repositories/Workspaces.php
@@ -119,6 +119,9 @@ class Workspaces extends AbstractRepositoriesApi
         return new Commits($this->getClient(), $this->workspace, $repo);
     }
 
+    /**
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     */
     public function components(string $repo): Components
     {
         return new Components($this->getClient(), $this->workspace, $repo);
@@ -174,6 +177,9 @@ class Workspaces extends AbstractRepositoriesApi
         return new Hooks($this->getClient(), $this->workspace, $repo);
     }
 
+    /**
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     */
     public function issues(string $repo): Issues
     {
         return new Issues($this->getClient(), $this->workspace, $repo);
@@ -184,6 +190,9 @@ class Workspaces extends AbstractRepositoriesApi
         return new MergeBases($this->getClient(), $this->workspace, $repo);
     }
 
+    /**
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     */
     public function milestones(string $repo): Milestones
     {
         return new Milestones($this->getClient(), $this->workspace, $repo);
@@ -224,6 +233,9 @@ class Workspaces extends AbstractRepositoriesApi
         return new Src($this->getClient(), $this->workspace, $repo);
     }
 
+    /**
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     */
     public function versions(string $repo): Versions
     {
         return new Versions($this->getClient(), $this->workspace, $repo);

--- a/src/Api/Repositories/Workspaces/Components.php
+++ b/src/Api/Repositories/Workspaces/Components.php
@@ -24,6 +24,8 @@ class Components extends AbstractWorkspacesApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function list(array $params = []): array
     {
@@ -34,6 +36,8 @@ class Components extends AbstractWorkspacesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function show(string $component, array $params = []): array
     {

--- a/src/Api/Repositories/Workspaces/Components.php
+++ b/src/Api/Repositories/Workspaces/Components.php
@@ -25,7 +25,7 @@ class Components extends AbstractWorkspacesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function list(array $params = []): array
     {
@@ -37,7 +37,7 @@ class Components extends AbstractWorkspacesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function show(string $component, array $params = []): array
     {

--- a/src/Api/Repositories/Workspaces/Issues.php
+++ b/src/Api/Repositories/Workspaces/Issues.php
@@ -29,6 +29,8 @@ class Issues extends AbstractWorkspacesApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function list(array $params = []): array
     {
@@ -39,6 +41,8 @@ class Issues extends AbstractWorkspacesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function create(array $params = []): array
     {
@@ -49,6 +53,8 @@ class Issues extends AbstractWorkspacesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function show(string $issue, array $params = []): array
     {
@@ -59,6 +65,8 @@ class Issues extends AbstractWorkspacesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function update(string $issue, array $params = []): array
     {
@@ -69,6 +77,8 @@ class Issues extends AbstractWorkspacesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function remove(string $issue, array $params = []): array
     {
@@ -77,26 +87,41 @@ class Issues extends AbstractWorkspacesApi
         return $this->delete($uri, $params);
     }
 
+    /**
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     */
     public function attachments(string $issue): Attachments
     {
         return new Attachments($this->getClient(), $this->workspace, $this->repo, $issue);
     }
 
+    /**
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     */
     public function changes(string $issue): Changes
     {
         return new Changes($this->getClient(), $this->workspace, $this->repo, $issue);
     }
 
+    /**
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     */
     public function comments(string $issue): Comments
     {
         return new Comments($this->getClient(), $this->workspace, $this->repo, $issue);
     }
 
+    /**
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     */
     public function voting(string $issue): Voting
     {
         return new Voting($this->getClient(), $this->workspace, $this->repo, $issue);
     }
 
+    /**
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     */
     public function watching(string $issue): Watching
     {
         return new Watching($this->getClient(), $this->workspace, $this->repo, $issue);

--- a/src/Api/Repositories/Workspaces/Issues.php
+++ b/src/Api/Repositories/Workspaces/Issues.php
@@ -30,7 +30,7 @@ class Issues extends AbstractWorkspacesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function list(array $params = []): array
     {
@@ -42,7 +42,7 @@ class Issues extends AbstractWorkspacesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function create(array $params = []): array
     {
@@ -54,7 +54,7 @@ class Issues extends AbstractWorkspacesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function show(string $issue, array $params = []): array
     {
@@ -66,7 +66,7 @@ class Issues extends AbstractWorkspacesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function update(string $issue, array $params = []): array
     {
@@ -78,7 +78,7 @@ class Issues extends AbstractWorkspacesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function remove(string $issue, array $params = []): array
     {
@@ -88,7 +88,7 @@ class Issues extends AbstractWorkspacesApi
     }
 
     /**
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function attachments(string $issue): Attachments
     {
@@ -96,7 +96,7 @@ class Issues extends AbstractWorkspacesApi
     }
 
     /**
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function changes(string $issue): Changes
     {
@@ -104,7 +104,7 @@ class Issues extends AbstractWorkspacesApi
     }
 
     /**
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function comments(string $issue): Comments
     {
@@ -112,7 +112,7 @@ class Issues extends AbstractWorkspacesApi
     }
 
     /**
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function voting(string $issue): Voting
     {
@@ -120,7 +120,7 @@ class Issues extends AbstractWorkspacesApi
     }
 
     /**
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function watching(string $issue): Watching
     {

--- a/src/Api/Repositories/Workspaces/Issues/Attachments.php
+++ b/src/Api/Repositories/Workspaces/Issues/Attachments.php
@@ -27,6 +27,8 @@ class Attachments extends AbstractIssuesApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function list(array $params = []): array
     {
@@ -37,6 +39,8 @@ class Attachments extends AbstractIssuesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function upload(FileResource $file): array
     {
@@ -49,6 +53,8 @@ class Attachments extends AbstractIssuesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function download(string $filename, array $params = []): \Psr\Http\Message\StreamInterface
     {
@@ -59,6 +65,8 @@ class Attachments extends AbstractIssuesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function remove(string $filename, array $params = []): array
     {

--- a/src/Api/Repositories/Workspaces/Issues/Attachments.php
+++ b/src/Api/Repositories/Workspaces/Issues/Attachments.php
@@ -28,7 +28,7 @@ class Attachments extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function list(array $params = []): array
     {
@@ -40,7 +40,7 @@ class Attachments extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function upload(FileResource $file): array
     {
@@ -54,7 +54,7 @@ class Attachments extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function download(string $filename, array $params = []): \Psr\Http\Message\StreamInterface
     {
@@ -66,7 +66,7 @@ class Attachments extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function remove(string $filename, array $params = []): array
     {

--- a/src/Api/Repositories/Workspaces/Issues/Changes.php
+++ b/src/Api/Repositories/Workspaces/Issues/Changes.php
@@ -25,7 +25,7 @@ class Changes extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function list(array $params = []): array
     {
@@ -37,7 +37,7 @@ class Changes extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function create(array $params = []): array
     {
@@ -49,7 +49,7 @@ class Changes extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function show(string $change, array $params = []): array
     {

--- a/src/Api/Repositories/Workspaces/Issues/Changes.php
+++ b/src/Api/Repositories/Workspaces/Issues/Changes.php
@@ -24,6 +24,8 @@ class Changes extends AbstractIssuesApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function list(array $params = []): array
     {
@@ -34,6 +36,8 @@ class Changes extends AbstractIssuesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function create(array $params = []): array
     {
@@ -44,6 +48,8 @@ class Changes extends AbstractIssuesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function show(string $change, array $params = []): array
     {

--- a/src/Api/Repositories/Workspaces/Issues/Comments.php
+++ b/src/Api/Repositories/Workspaces/Issues/Comments.php
@@ -24,6 +24,8 @@ class Comments extends AbstractIssuesApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function list(array $params = []): array
     {
@@ -34,6 +36,8 @@ class Comments extends AbstractIssuesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function show(string $comment, array $params = []): array
     {
@@ -44,6 +48,8 @@ class Comments extends AbstractIssuesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function create(array $params = []): array
     {
@@ -54,6 +60,8 @@ class Comments extends AbstractIssuesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function update(string $comment, array $params = []): array
     {
@@ -64,6 +72,8 @@ class Comments extends AbstractIssuesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function remove(string $comment): array
     {

--- a/src/Api/Repositories/Workspaces/Issues/Comments.php
+++ b/src/Api/Repositories/Workspaces/Issues/Comments.php
@@ -25,7 +25,7 @@ class Comments extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function list(array $params = []): array
     {
@@ -37,7 +37,7 @@ class Comments extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function show(string $comment, array $params = []): array
     {
@@ -49,7 +49,7 @@ class Comments extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function create(array $params = []): array
     {
@@ -61,7 +61,7 @@ class Comments extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function update(string $comment, array $params = []): array
     {
@@ -73,7 +73,7 @@ class Comments extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function remove(string $comment): array
     {

--- a/src/Api/Repositories/Workspaces/Issues/Voting.php
+++ b/src/Api/Repositories/Workspaces/Issues/Voting.php
@@ -25,7 +25,7 @@ class Voting extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function check(array $params = []): array
     {
@@ -37,7 +37,7 @@ class Voting extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function vote(array $params = []): array
     {
@@ -49,7 +49,7 @@ class Voting extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function retract(array $params = []): array
     {

--- a/src/Api/Repositories/Workspaces/Issues/Voting.php
+++ b/src/Api/Repositories/Workspaces/Issues/Voting.php
@@ -24,6 +24,8 @@ class Voting extends AbstractIssuesApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function check(array $params = []): array
     {
@@ -34,6 +36,8 @@ class Voting extends AbstractIssuesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function vote(array $params = []): array
     {
@@ -44,6 +48,8 @@ class Voting extends AbstractIssuesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function retract(array $params = []): array
     {

--- a/src/Api/Repositories/Workspaces/Issues/Watching.php
+++ b/src/Api/Repositories/Workspaces/Issues/Watching.php
@@ -25,7 +25,7 @@ class Watching extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function check(array $params = []): array
     {
@@ -37,7 +37,7 @@ class Watching extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function watch(array $params = []): array
     {
@@ -49,7 +49,7 @@ class Watching extends AbstractIssuesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function ignore(array $params = []): array
     {

--- a/src/Api/Repositories/Workspaces/Issues/Watching.php
+++ b/src/Api/Repositories/Workspaces/Issues/Watching.php
@@ -24,6 +24,8 @@ class Watching extends AbstractIssuesApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function check(array $params = []): array
     {
@@ -34,6 +36,8 @@ class Watching extends AbstractIssuesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function watch(array $params = []): array
     {
@@ -44,6 +48,8 @@ class Watching extends AbstractIssuesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function ignore(array $params = []): array
     {

--- a/src/Api/Repositories/Workspaces/Milestones.php
+++ b/src/Api/Repositories/Workspaces/Milestones.php
@@ -24,6 +24,8 @@ class Milestones extends AbstractWorkspacesApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function list(array $params = []): array
     {
@@ -34,6 +36,8 @@ class Milestones extends AbstractWorkspacesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function show(string $milestone, array $params = []): array
     {

--- a/src/Api/Repositories/Workspaces/Milestones.php
+++ b/src/Api/Repositories/Workspaces/Milestones.php
@@ -25,7 +25,7 @@ class Milestones extends AbstractWorkspacesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function list(array $params = []): array
     {
@@ -37,7 +37,7 @@ class Milestones extends AbstractWorkspacesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function show(string $milestone, array $params = []): array
     {

--- a/src/Api/Repositories/Workspaces/Versions.php
+++ b/src/Api/Repositories/Workspaces/Versions.php
@@ -24,6 +24,8 @@ class Versions extends AbstractWorkspacesApi
 {
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function list(array $params = []): array
     {
@@ -34,6 +36,8 @@ class Versions extends AbstractWorkspacesApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Bitbucket has deprecated native issue tracker APIs.
      */
     public function show(string $version, array $params = []): array
     {

--- a/src/Api/Repositories/Workspaces/Versions.php
+++ b/src/Api/Repositories/Workspaces/Versions.php
@@ -25,7 +25,7 @@ class Versions extends AbstractWorkspacesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function list(array $params = []): array
     {
@@ -37,7 +37,7 @@ class Versions extends AbstractWorkspacesApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Bitbucket has deprecated native issue tracker APIs.
+     * @deprecated bitbucket has deprecated native issue tracker APIs
      */
     public function show(string $version, array $params = []): array
     {


### PR DESCRIPTION
## Summary
- Deprecate native issue tracker entry points on repository workspaces.
- Deprecate components, issues, issue attachments, issue changes, issue comments, issue voting, issue watching, milestones, and versions methods.
- Update the V5.1 changelog, keeping deprecation entries grouped at the end.

## Testing
- `php -l src/Api/Repositories/Workspaces.php`
- `php -l src/Api/Repositories/Workspaces/Components.php`
- `php -l src/Api/Repositories/Workspaces/Issues.php`
- `php -l src/Api/Repositories/Workspaces/Milestones.php`
- `php -l src/Api/Repositories/Workspaces/Versions.php`
- `php -l src/Api/Repositories/Workspaces/Issues/Attachments.php`
- `php -l src/Api/Repositories/Workspaces/Issues/Changes.php`
- `php -l src/Api/Repositories/Workspaces/Issues/Comments.php`
- `php -l src/Api/Repositories/Workspaces/Issues/Voting.php`
- `php -l src/Api/Repositories/Workspaces/Issues/Watching.php`
- No tests added to stay consistent with the existing test style for this API surface.
- Existing PHPUnit/PHPStan/Psalm binaries are not installed in this checkout (`vendor-bin/*/vendor/bin/*` missing).