### PR TITLE
Deprecate current user team permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGE LOG
 * Deprecated workspace code search
 * Deprecated addon linker methods
 * Deprecated native issue tracker methods
+* Deprecated current user team permissions
 
 
 ## V5.0 (23/02/2025)

--- a/src/Api/CurrentUser.php
+++ b/src/Api/CurrentUser.php
@@ -68,7 +68,7 @@ class CurrentUser extends AbstractApi
     /**
      * @throws \Http\Client\Exception
      *
-     * @deprecated Teams have been superseded by workspaces.
+     * @deprecated teams have been superseded by workspaces
      */
     public function listTeamPermissions(array $params = []): array
     {

--- a/src/Api/CurrentUser.php
+++ b/src/Api/CurrentUser.php
@@ -67,6 +67,8 @@ class CurrentUser extends AbstractApi
 
     /**
      * @throws \Http\Client\Exception
+     *
+     * @deprecated Teams have been superseded by workspaces.
      */
     public function listTeamPermissions(array $params = []): array
     {


### PR DESCRIPTION
## Summary
- Deprecate `CurrentUser::listTeamPermissions()` because teams have been superseded by workspaces.
- Update the V5.1 changelog, keeping deprecation entries grouped at the end.

## Testing
- `php -l src/Api/CurrentUser.php`
- No tests added to stay consistent with the existing test style for this API surface.
- Existing PHPUnit/PHPStan/Psalm binaries are not installed in this checkout (`vendor-bin/*/vendor/bin/*` missing).