### PR TITLE
Add repository pipelines config subresources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGE LOG
 * Fixed the current user workspaces endpoint
 * Added the current user workspaces API
 * Added the workspace pull requests endpoint for a selected user
+* Added repository pipelines config subresources
 * Documented Bitbucket API migration paths
 * Deprecated current user workspaces pass-through methods
 * Deprecated the top-level pull requests pass-through method

--- a/src/Api/Repositories/Workspaces/PipelinesConfig.php
+++ b/src/Api/Repositories/Workspaces/PipelinesConfig.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Bitbucket\Api\Repositories\Workspaces;
 
+use Bitbucket\Api\Repositories\Workspaces\PipelinesConfig\BuildNumber;
+use Bitbucket\Api\Repositories\Workspaces\PipelinesConfig\Schedules;
+use Bitbucket\Api\Repositories\Workspaces\PipelinesConfig\Ssh;
 use Bitbucket\Api\Repositories\Workspaces\PipelinesConfig\Variables;
 use Bitbucket\HttpClient\Util\UriBuilder;
 
@@ -23,6 +26,21 @@ use Bitbucket\HttpClient\Util\UriBuilder;
  */
 class PipelinesConfig extends AbstractWorkspacesApi
 {
+    public function buildNumber(): BuildNumber
+    {
+        return new BuildNumber($this->getClient(), $this->workspace, $this->repo);
+    }
+
+    public function schedules(): Schedules
+    {
+        return new Schedules($this->getClient(), $this->workspace, $this->repo);
+    }
+
+    public function ssh(): Ssh
+    {
+        return new Ssh($this->getClient(), $this->workspace, $this->repo);
+    }
+
     public function variables(): Variables
     {
         return new Variables($this->getClient(), $this->workspace, $this->repo);


### PR DESCRIPTION
## Summary
- Add `pipelinesConfig($repo)->ssh()` for the existing repository pipelines config SSH API.
- Add `pipelinesConfig($repo)->buildNumber()` and `pipelinesConfig($repo)->schedules()` accessors for existing subresources.
- Update the V5.1 changelog.

## Notes
- Fixes #93.
- Supersedes #94 by adding `ssh()` under `pipelinesConfig()`, which matches Bitbucket's `/pipelines_config/ssh/...` endpoints.

## Testing
- `php -l src/Api/Repositories/Workspaces/PipelinesConfig.php`
- No tests added to stay consistent with the existing test style for this API surface.
- Existing PHPUnit/PHPStan/Psalm binaries are not installed in this checkout (`vendor-bin/*/vendor/bin/*` missing).