### PR TITLE
Preserve ResultPager metadata when using fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGE LOG
 * Added the current user workspaces API
 * Added the workspace pull requests endpoint for a selected user
 * Added repository pipelines config subresources
+* Fixed result pager pagination when using partial response fields
 * Documented Bitbucket API migration paths
 * Deprecated current user workspaces pass-through methods
 * Deprecated the top-level pull requests pass-through method

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -33,6 +33,13 @@ abstract class AbstractApi
      */
     private const URI_PREFIX = '/2.0/';
 
+    /**
+     * The pagination fields.
+     *
+     * @var string[]
+     */
+    private const PAGINATION_FIELDS = ['size', 'page', 'pagelen', 'next', 'previous'];
+
     private readonly Client $client;
 
     private ?int $perPage;
@@ -60,8 +67,14 @@ abstract class AbstractApi
      */
     protected function getAsResponse(string $uri, array $params = [], array $headers = []): ResponseInterface
     {
-        if (null !== $this->perPage && !isset($params['pagelen'])) {
-            $params['pagelen'] = $this->perPage;
+        if (null !== $this->perPage) {
+            if (!isset($params['pagelen'])) {
+                $params['pagelen'] = $this->perPage;
+            }
+
+            if (isset($params['fields']) && \is_string($params['fields']) && '' !== \trim($params['fields'])) {
+                $params['fields'] = self::withPaginationFields($params['fields']);
+            }
         }
 
         return $this->client->getHttpClient()->get(self::prepareUri($uri, $params), $headers);
@@ -183,6 +196,59 @@ abstract class AbstractApi
     private static function prepareUri(string $uri, array $query = []): string
     {
         return \sprintf('%s%s%s', self::URI_PREFIX, $uri, QueryStringBuilder::build($query));
+    }
+
+    /**
+     * Add the pagination fields to the given fields parameter.
+     */
+    private static function withPaginationFields(string $fields): string
+    {
+        $parts = \array_values(\array_filter(
+            \array_map('trim', \explode(',', $fields)),
+            static function (string $field): bool {
+                return '' !== $field;
+            }
+        ));
+
+        if ([] === $parts) {
+            return $fields;
+        }
+
+        $prefix = self::usesAdditiveFields($parts) ? '+' : '';
+
+        foreach (self::PAGINATION_FIELDS as $field) {
+            if (!self::containsIncludedField($parts, $field)) {
+                $parts[] = $prefix.$field;
+            }
+        }
+
+        return \implode(',', $parts);
+    }
+
+    /**
+     * @param string[] $fields
+     */
+    private static function usesAdditiveFields(array $fields): bool
+    {
+        if (\in_array('-*', $fields, true)) {
+            return true;
+        }
+
+        foreach ($fields as $field) {
+            if (!\str_starts_with($field, '+') && !\str_starts_with($field, '-')) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string[] $fields
+     */
+    private static function containsIncludedField(array $fields, string $field): bool
+    {
+        return \in_array($field, $fields, true) || \in_array("+{$field}", $fields, true);
     }
 
     /**

--- a/tests/ResultPagerTest.php
+++ b/tests/ResultPagerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Tests;
+
+use Bitbucket\Client;
+use Bitbucket\HttpClient\Builder;
+use Bitbucket\HttpClient\Util\JsonArray;
+use Bitbucket\ResultPager;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
+use Http\Mock\Client as MockClient;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+class ResultPagerTest extends TestCase
+{
+    public function testFetchAllPreservesPaginationFields(): void
+    {
+        $httpClient = new MockClient();
+
+        $httpClient->addResponse(self::jsonResponse([
+            'pagelen' => 1,
+            'next'    => 'https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/refs/tags?page=2',
+            'values'  => [
+                ['name' => 'v1.0.0'],
+            ],
+        ]));
+
+        $httpClient->addResponse(self::jsonResponse([
+            'pagelen' => 1,
+            'values'  => [
+                ['name' => 'v1.0.1'],
+            ],
+        ]));
+
+        $client = new Client(new Builder($httpClient));
+        $pager = new ResultPager($client, 1);
+
+        $tags = $pager->fetchAll(
+            $client->repositories()->workspaces('my-workspace')->refs('my-repo')->tags(),
+            'list',
+            [['fields' => 'values.name']]
+        );
+
+        self::assertSame([['name' => 'v1.0.0'], ['name' => 'v1.0.1']], $tags);
+
+        $requests = $httpClient->getRequests();
+        $query = [];
+        \parse_str($requests[0]->getUri()->getQuery(), $query);
+
+        self::assertSame('values.name,size,page,pagelen,next,previous', $query['fields']);
+    }
+
+    public function testDirectCallsDoNotPreservePaginationFields(): void
+    {
+        $httpClient = new MockClient();
+
+        $httpClient->addResponse(self::jsonResponse(['values' => []]));
+
+        $client = new Client(new Builder($httpClient));
+
+        $client->repositories()
+            ->workspaces('my-workspace')
+            ->refs('my-repo')
+            ->tags()
+            ->list(['fields' => 'values.name']);
+
+        $query = [];
+        \parse_str($httpClient->getLastRequest()->getUri()->getQuery(), $query);
+
+        self::assertSame('values.name', $query['fields']);
+    }
+
+    private static function jsonResponse(array $data): Response
+    {
+        return new Response(
+            200,
+            ['Content-Type' => 'application/json'],
+            Utils::streamFor(JsonArray::encode($data))
+        );
+    }
+}

--- a/tests/ResultPagerTest.php
+++ b/tests/ResultPagerTest.php
@@ -33,15 +33,15 @@ class ResultPagerTest extends TestCase
 
         $httpClient->addResponse(self::jsonResponse([
             'pagelen' => 1,
-            'next'    => 'https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/refs/tags?page=2',
-            'values'  => [
+            'next' => 'https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/refs/tags?page=2',
+            'values' => [
                 ['name' => 'v1.0.0'],
             ],
         ]));
 
         $httpClient->addResponse(self::jsonResponse([
             'pagelen' => 1,
-            'values'  => [
+            'values' => [
                 ['name' => 'v1.0.1'],
             ],
         ]));


### PR DESCRIPTION
## Summary
- Preserve Bitbucket pagination metadata when `ResultPager` is used with partial response `fields`.
- Keep direct non-pager API calls unchanged.
- Add focused `ResultPager` coverage for amended `fields` and direct calls.
- Update the V5.1 changelog.

## Notes
- Fixes #91.
- Bitbucket treats pagination links as opaque, so the pager must request `next` instead of constructing follow-up page URLs.

## Testing
- `php -l src/Api/AbstractApi.php`
- `php -l tests/ResultPagerTest.php`
- `git diff --check`
- Attempted `vendor-bin/phpunit/vendor/bin/phpunit --filter ResultPagerTest`, but the phpunit binary is not installed in this checkout (`vendor-bin/phpunit/vendor/bin/phpunit` missing).