### PR TITLE
Fix source directory listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGE LOG
 * Added repository pipelines config subresources
 * Fixed result pager pagination when using partial response fields
 * Fixed result pager previous-page navigation
+* Fixed source directory listings for specific revisions
 * Documented Bitbucket API migration paths
 * Deprecated current user workspaces pass-through methods
 * Deprecated the top-level pull requests pass-through method

--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ $tags = $paginator->fetchAll($tagsClient, 'list', [['q' => 'name ~ "v1"', 'sort'
 
 Bitbucket includes those query parameters in the `next` pagination URL, so subsequent pages preserve them automatically.
 
+To list files from a specific branch or commit, use the source API with `ResultPager`. Directory listings include both `commit_file` and `commit_directory` entries, so filter the returned values by `type` if you only need files:
+
+```php
+$paginator = new Bitbucket\ResultPager($client);
+
+$srcClient = $client->repositories()
+    ->workspaces('abc')
+    ->src('xyz');
+
+$entries = $paginator->fetchAll($srcClient, 'show', ['demo', '/', ['max_depth' => 10]]);
+```
+
 
 ### Migrating Deprecated Bitbucket Endpoints
 

--- a/src/Api/Repositories/Workspaces/Src.php
+++ b/src/Api/Repositories/Workspaces/Src.php
@@ -80,9 +80,20 @@ class Src extends AbstractWorkspacesApi
      */
     public function show(string $commit, string $filepath, array $params = []): array
     {
-        $uri = $this->buildSrcUri($commit, ...\explode('/', $filepath));
+        $isDirectory = '' === $filepath || \str_ends_with($filepath, '/');
+        $filepath = \trim($filepath, '/');
 
-        if (!isset($params['format'])) {
+        if ('' === $filepath) {
+            $uri = UriBuilder::appendSeparator($this->buildSrcUri($commit));
+        } else {
+            $uri = $this->buildSrcUri($commit, ...\explode('/', $filepath));
+
+            if ($isDirectory) {
+                $uri = UriBuilder::appendSeparator($uri);
+            }
+        }
+
+        if (!$isDirectory && !isset($params['format'])) {
             $params['format'] = 'meta';
         }
 

--- a/tests/ApiUrlTest.php
+++ b/tests/ApiUrlTest.php
@@ -38,6 +38,71 @@ class ApiUrlTest extends TestCase
         );
     }
 
+    public function testWorkspaceSrcShowRootDirectoryUri(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->src('my-project')
+            ->show('main', '/');
+
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/src/main/',
+            (string) $this->httpClient->getLastRequest()->getUri()
+        );
+    }
+
+    public function testWorkspaceSrcShowEmptyRootDirectoryUri(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->src('my-project')
+            ->show('main', '');
+
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/src/main/',
+            (string) $this->httpClient->getLastRequest()->getUri()
+        );
+    }
+
+    public function testWorkspaceSrcShowRootDirectoryUriWithMaxDepth(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->src('my-project')
+            ->show('main', '/', ['max_depth' => 10]);
+
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/src/main/?max_depth=10',
+            (string) $this->httpClient->getLastRequest()->getUri()
+        );
+    }
+
+    public function testWorkspaceSrcShowDirectoryUri(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->src('my-project')
+            ->show('main', 'docs/');
+
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/src/main/docs/',
+            (string) $this->httpClient->getLastRequest()->getUri()
+        );
+    }
+
+    public function testWorkspaceSrcShowDirectoryUriWithSlashInBranchName(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->src('my-project')
+            ->show('feature/demo', '/');
+
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/src/feature%2Fdemo/',
+            (string) $this->httpClient->getLastRequest()->getUri()
+        );
+    }
+
     #[DataProvider('dataProvider')]
     public function testWorkspaceSrcDownloadUri(string $fileName): void
     {


### PR DESCRIPTION
- Fix source directory listing URLs for root and trailing-slash paths at a specific revision
- Preserve existing file metadata behavior for non-directory source paths
- Add URL regression coverage and README guidance for recursive source listings

Fixes #81