### PR TITLE
Add repository permissions config APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGE LOG
 * Added the current user workspaces API
 * Added the workspace pull requests endpoint for a selected user
 * Added repository pipelines config subresources
+* Added repository permissions config APIs
 * Fixed result pager pagination when using partial response fields
 * Fixed result pager previous-page navigation
 * Fixed source directory listings for specific revisions

--- a/src/Api/Repositories/Workspaces.php
+++ b/src/Api/Repositories/Workspaces.php
@@ -32,6 +32,7 @@ use Bitbucket\Api\Repositories\Workspaces\Issues;
 use Bitbucket\Api\Repositories\Workspaces\MergeBases;
 use Bitbucket\Api\Repositories\Workspaces\Milestones;
 use Bitbucket\Api\Repositories\Workspaces\Patches;
+use Bitbucket\Api\Repositories\Workspaces\PermissionsConfig;
 use Bitbucket\Api\Repositories\Workspaces\Pipelines;
 use Bitbucket\Api\Repositories\Workspaces\PipelinesConfig;
 use Bitbucket\Api\Repositories\Workspaces\Properties;
@@ -201,6 +202,11 @@ class Workspaces extends AbstractRepositoriesApi
     public function patches(string $repo): Patches
     {
         return new Patches($this->getClient(), $this->workspace, $repo);
+    }
+
+    public function permissionsConfig(string $repo): PermissionsConfig
+    {
+        return new PermissionsConfig($this->getClient(), $this->workspace, $repo);
     }
 
     public function pipelines(string $repo): Pipelines

--- a/src/Api/Repositories/Workspaces/PermissionsConfig.php
+++ b/src/Api/Repositories/Workspaces/PermissionsConfig.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\Repositories\Workspaces;
+
+use Bitbucket\Api\Repositories\Workspaces\PermissionsConfig\Groups;
+use Bitbucket\Api\Repositories\Workspaces\PermissionsConfig\Users;
+
+/**
+ * The permissions config API class.
+ *
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+class PermissionsConfig extends AbstractWorkspacesApi
+{
+    public function groups(): Groups
+    {
+        return new Groups($this->getClient(), $this->workspace, $this->repo);
+    }
+
+    public function users(): Users
+    {
+        return new Users($this->getClient(), $this->workspace, $this->repo);
+    }
+}

--- a/src/Api/Repositories/Workspaces/PermissionsConfig/AbstractPermissionsConfigApi.php
+++ b/src/Api/Repositories/Workspaces/PermissionsConfig/AbstractPermissionsConfigApi.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\Repositories\Workspaces\PermissionsConfig;
+
+use Bitbucket\Api\Repositories\Workspaces\AbstractWorkspacesApi;
+
+/**
+ * The abstract permissions config API class.
+ *
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+abstract class AbstractPermissionsConfigApi extends AbstractWorkspacesApi
+{
+}

--- a/src/Api/Repositories/Workspaces/PermissionsConfig/Groups.php
+++ b/src/Api/Repositories/Workspaces/PermissionsConfig/Groups.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\Repositories\Workspaces\PermissionsConfig;
+
+use Bitbucket\HttpClient\Util\UriBuilder;
+
+/**
+ * The groups API class.
+ *
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+class Groups extends AbstractPermissionsConfigApi
+{
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function list(array $params = []): array
+    {
+        $uri = $this->buildGroupsUri();
+
+        return $this->get($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function show(string $group, array $params = []): array
+    {
+        $uri = $this->buildGroupsUri($group);
+
+        return $this->get($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function update(string $group, array $params = []): array
+    {
+        $uri = $this->buildGroupsUri($group);
+
+        return $this->put($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function remove(string $group, array $params = []): array
+    {
+        $uri = $this->buildGroupsUri($group);
+
+        return $this->delete($uri, $params);
+    }
+
+    /**
+     * Build the groups URI from the given parts.
+     */
+    protected function buildGroupsUri(string ...$parts): string
+    {
+        return UriBuilder::build('repositories', $this->workspace, $this->repo, 'permissions-config', 'groups', ...$parts);
+    }
+}

--- a/src/Api/Repositories/Workspaces/PermissionsConfig/Users.php
+++ b/src/Api/Repositories/Workspaces/PermissionsConfig/Users.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\Repositories\Workspaces\PermissionsConfig;
+
+use Bitbucket\HttpClient\Util\UriBuilder;
+
+/**
+ * The users API class.
+ *
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+class Users extends AbstractPermissionsConfigApi
+{
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function list(array $params = []): array
+    {
+        $uri = $this->buildUsersUri();
+
+        return $this->get($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function show(string $selectedUserId, array $params = []): array
+    {
+        $uri = $this->buildUsersUri($selectedUserId);
+
+        return $this->get($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function update(string $selectedUserId, array $params = []): array
+    {
+        $uri = $this->buildUsersUri($selectedUserId);
+
+        return $this->put($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function remove(string $selectedUserId, array $params = []): array
+    {
+        $uri = $this->buildUsersUri($selectedUserId);
+
+        return $this->delete($uri, $params);
+    }
+
+    /**
+     * Build the users URI from the given parts.
+     */
+    protected function buildUsersUri(string ...$parts): string
+    {
+        return UriBuilder::build('repositories', $this->workspace, $this->repo, 'permissions-config', 'users', ...$parts);
+    }
+}

--- a/tests/ApiUrlTest.php
+++ b/tests/ApiUrlTest.php
@@ -145,6 +145,144 @@ class ApiUrlTest extends TestCase
         );
     }
 
+    public function testWorkspacePermissionsConfigGroupsListUri(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->permissionsConfig('my-project')
+            ->groups()
+            ->list(['pagelen' => 50]);
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/permissions-config/groups?pagelen=50',
+            (string) $request->getUri()
+        );
+    }
+
+    public function testWorkspacePermissionsConfigGroupsShowUri(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->permissionsConfig('my-project')
+            ->groups()
+            ->show('developers');
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/permissions-config/groups/developers',
+            (string) $request->getUri()
+        );
+    }
+
+    public function testWorkspacePermissionsConfigGroupsUpdateUri(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->permissionsConfig('my-project')
+            ->groups()
+            ->update('developers', ['permission' => 'write']);
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('PUT', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/permissions-config/groups/developers',
+            (string) $request->getUri()
+        );
+        $this->assertSame('{"permission":"write"}', (string) $request->getBody());
+    }
+
+    public function testWorkspacePermissionsConfigGroupsRemoveUri(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->permissionsConfig('my-project')
+            ->groups()
+            ->remove('developers');
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/permissions-config/groups/developers',
+            (string) $request->getUri()
+        );
+    }
+
+    public function testWorkspacePermissionsConfigUsersListUri(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->permissionsConfig('my-project')
+            ->users()
+            ->list(['pagelen' => 50]);
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/permissions-config/users?pagelen=50',
+            (string) $request->getUri()
+        );
+    }
+
+    public function testWorkspacePermissionsConfigUsersShowUri(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->permissionsConfig('my-project')
+            ->users()
+            ->show('{abc-123}');
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/permissions-config/users/%7Babc-123%7D',
+            (string) $request->getUri()
+        );
+    }
+
+    public function testWorkspacePermissionsConfigUsersUpdateUri(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->permissionsConfig('my-project')
+            ->users()
+            ->update('{abc-123}', ['permission' => 'admin']);
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('PUT', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/permissions-config/users/%7Babc-123%7D',
+            (string) $request->getUri()
+        );
+        $this->assertSame('{"permission":"admin"}', (string) $request->getBody());
+    }
+
+    public function testWorkspacePermissionsConfigUsersRemoveUri(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->permissionsConfig('my-project')
+            ->users()
+            ->remove('{abc-123}');
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/permissions-config/users/%7Babc-123%7D',
+            (string) $request->getUri()
+        );
+    }
+
     public static function dataProvider(): array
     {
         return [


### PR DESCRIPTION
Add repository permissions-config support for explicit repository user and group permissions. This exposes list, show, update, and remove operations for Bitbucket's users and groups permissions-config endpoints. Fixes #82.