### PR TITLE
Add effective branching model endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGE LOG
 * Fixed the current user workspaces endpoint
 * Added the current user workspaces API
 * Added the workspace pull requests endpoint for a selected user
+* Added repository effective branching model API
 * Added repository pipelines config subresources
 * Added repository permissions config APIs
 * Fixed result pager pagination when using partial response fields

--- a/src/Api/Repositories/Workspaces.php
+++ b/src/Api/Repositories/Workspaces.php
@@ -24,6 +24,7 @@ use Bitbucket\Api\Repositories\Workspaces\Deployments;
 use Bitbucket\Api\Repositories\Workspaces\Diffs;
 use Bitbucket\Api\Repositories\Workspaces\DiffStat;
 use Bitbucket\Api\Repositories\Workspaces\Downloads;
+use Bitbucket\Api\Repositories\Workspaces\EffectiveBranchingModel;
 use Bitbucket\Api\Repositories\Workspaces\Environments;
 use Bitbucket\Api\Repositories\Workspaces\FileHistory;
 use Bitbucket\Api\Repositories\Workspaces\Forks;
@@ -103,6 +104,11 @@ class Workspaces extends AbstractRepositoriesApi
     public function branchingModel(string $repo): BranchingModel
     {
         return new BranchingModel($this->getClient(), $this->workspace, $repo);
+    }
+
+    public function effectiveBranchingModel(string $repo): EffectiveBranchingModel
+    {
+        return new EffectiveBranchingModel($this->getClient(), $this->workspace, $repo);
     }
 
     public function branchRestrictions(string $repo): BranchRestrictions

--- a/src/Api/Repositories/Workspaces/EffectiveBranchingModel.php
+++ b/src/Api/Repositories/Workspaces/EffectiveBranchingModel.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\Repositories\Workspaces;
+
+use Bitbucket\HttpClient\Util\UriBuilder;
+
+/**
+ * The effective branching model API class.
+ *
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+class EffectiveBranchingModel extends AbstractWorkspacesApi
+{
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function show(array $params = []): array
+    {
+        $uri = $this->buildEffectiveBranchingModelUri();
+
+        return $this->get($uri, $params);
+    }
+
+    /**
+     * Build the effective branching model URI from the given parts.
+     */
+    protected function buildEffectiveBranchingModelUri(string ...$parts): string
+    {
+        return UriBuilder::build('repositories', $this->workspace, $this->repo, 'effective-branching-model', ...$parts);
+    }
+}

--- a/tests/ApiUrlTest.php
+++ b/tests/ApiUrlTest.php
@@ -283,6 +283,38 @@ class ApiUrlTest extends TestCase
         );
     }
 
+    public function testWorkspaceEffectiveBranchingModelShowUri(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->effectiveBranchingModel('my-project')
+            ->show();
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/effective-branching-model',
+            (string) $request->getUri()
+        );
+    }
+
+    public function testWorkspaceEffectiveBranchingModelShowUriWithFields(): void
+    {
+        $this->client->repositories()
+            ->workspaces('my-workspace')
+            ->effectiveBranchingModel('my-project')
+            ->show(['fields' => 'development,production,branch_types']);
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/repositories/my-workspace/my-project/effective-branching-model?fields=development%2Cproduction%2Cbranch_types',
+            (string) $request->getUri()
+        );
+    }
+
     public static function dataProvider(): array
     {
         return [


### PR DESCRIPTION
Add support for Bitbucket's repository effective branching model endpoint so callers can retrieve the currently applied branching model for repositories that may inherit project settings. Fixes #88.