### PR TITLE
Add project permissions config APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGE LOG
 * Added repository effective branching model API
 * Added repository pipelines config subresources
 * Added repository permissions config APIs
+* Added project permissions config APIs
 * Fixed result pager pagination when using partial response fields
 * Fixed result pager previous-page navigation
 * Fixed source directory listings for specific revisions

--- a/src/Api/Workspaces/Projects.php
+++ b/src/Api/Workspaces/Projects.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Bitbucket\Api\Workspaces;
 
+use Bitbucket\Api\Workspaces\Projects\PermissionsConfig;
 use Bitbucket\HttpClient\Util\UriBuilder;
 
 /**
@@ -70,6 +71,11 @@ class Projects extends AbstractWorkspacesApi
         $uri = $this->buildProjectsUri($project);
 
         return $this->delete($uri, $params);
+    }
+
+    public function permissionsConfig(string $project): PermissionsConfig
+    {
+        return new PermissionsConfig($this->getClient(), $this->workspace, $project);
     }
 
     /**

--- a/src/Api/Workspaces/Projects/AbstractProjectsApi.php
+++ b/src/Api/Workspaces/Projects/AbstractProjectsApi.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\Workspaces\Projects;
+
+use Bitbucket\Api\Workspaces\AbstractWorkspacesApi;
+use Bitbucket\Client;
+
+/**
+ * The abstract projects API class.
+ *
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+abstract class AbstractProjectsApi extends AbstractWorkspacesApi
+{
+    protected readonly string $project;
+
+    public function __construct(Client $client, string $workspace, string $project)
+    {
+        parent::__construct($client, $workspace);
+        $this->project = $project;
+    }
+}

--- a/src/Api/Workspaces/Projects/PermissionsConfig.php
+++ b/src/Api/Workspaces/Projects/PermissionsConfig.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\Workspaces\Projects;
+
+use Bitbucket\Api\Workspaces\Projects\PermissionsConfig\Groups;
+use Bitbucket\Api\Workspaces\Projects\PermissionsConfig\Users;
+
+/**
+ * The permissions config API class.
+ *
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+class PermissionsConfig extends AbstractProjectsApi
+{
+    public function groups(): Groups
+    {
+        return new Groups($this->getClient(), $this->workspace, $this->project);
+    }
+
+    public function users(): Users
+    {
+        return new Users($this->getClient(), $this->workspace, $this->project);
+    }
+}

--- a/src/Api/Workspaces/Projects/PermissionsConfig/AbstractPermissionsConfigApi.php
+++ b/src/Api/Workspaces/Projects/PermissionsConfig/AbstractPermissionsConfigApi.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\Workspaces\Projects\PermissionsConfig;
+
+use Bitbucket\Api\Workspaces\Projects\AbstractProjectsApi;
+
+/**
+ * The abstract permissions config API class.
+ *
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+abstract class AbstractPermissionsConfigApi extends AbstractProjectsApi
+{
+}

--- a/src/Api/Workspaces/Projects/PermissionsConfig/Groups.php
+++ b/src/Api/Workspaces/Projects/PermissionsConfig/Groups.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\Workspaces\Projects\PermissionsConfig;
+
+use Bitbucket\HttpClient\Util\UriBuilder;
+
+/**
+ * The groups API class.
+ *
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+class Groups extends AbstractPermissionsConfigApi
+{
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function list(array $params = []): array
+    {
+        $uri = $this->buildGroupsUri();
+
+        return $this->get($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function show(string $group, array $params = []): array
+    {
+        $uri = $this->buildGroupsUri($group);
+
+        return $this->get($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function update(string $group, array $params = []): array
+    {
+        $uri = $this->buildGroupsUri($group);
+
+        return $this->put($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function remove(string $group, array $params = []): array
+    {
+        $uri = $this->buildGroupsUri($group);
+
+        return $this->delete($uri, $params);
+    }
+
+    /**
+     * Build the groups URI from the given parts.
+     */
+    protected function buildGroupsUri(string ...$parts): string
+    {
+        return UriBuilder::build('workspaces', $this->workspace, 'projects', $this->project, 'permissions-config', 'groups', ...$parts);
+    }
+}

--- a/src/Api/Workspaces/Projects/PermissionsConfig/Users.php
+++ b/src/Api/Workspaces/Projects/PermissionsConfig/Users.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bitbucket API Client.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bitbucket\Api\Workspaces\Projects\PermissionsConfig;
+
+use Bitbucket\HttpClient\Util\UriBuilder;
+
+/**
+ * The users API class.
+ *
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+class Users extends AbstractPermissionsConfigApi
+{
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function list(array $params = []): array
+    {
+        $uri = $this->buildUsersUri();
+
+        return $this->get($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function show(string $selectedUserId, array $params = []): array
+    {
+        $uri = $this->buildUsersUri($selectedUserId);
+
+        return $this->get($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function update(string $selectedUserId, array $params = []): array
+    {
+        $uri = $this->buildUsersUri($selectedUserId);
+
+        return $this->put($uri, $params);
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     */
+    public function remove(string $selectedUserId, array $params = []): array
+    {
+        $uri = $this->buildUsersUri($selectedUserId);
+
+        return $this->delete($uri, $params);
+    }
+
+    /**
+     * Build the users URI from the given parts.
+     */
+    protected function buildUsersUri(string ...$parts): string
+    {
+        return UriBuilder::build('workspaces', $this->workspace, 'projects', $this->project, 'permissions-config', 'users', ...$parts);
+    }
+}

--- a/tests/ApiUrlTest.php
+++ b/tests/ApiUrlTest.php
@@ -283,6 +283,144 @@ class ApiUrlTest extends TestCase
         );
     }
 
+    public function testWorkspaceProjectPermissionsConfigGroupsListUri(): void
+    {
+        $this->client->workspaces('my-workspace')
+            ->projects()
+            ->permissionsConfig('PROJ')
+            ->groups()
+            ->list(['pagelen' => 50]);
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/workspaces/my-workspace/projects/PROJ/permissions-config/groups?pagelen=50',
+            (string) $request->getUri()
+        );
+    }
+
+    public function testWorkspaceProjectPermissionsConfigGroupsShowUri(): void
+    {
+        $this->client->workspaces('my-workspace')
+            ->projects()
+            ->permissionsConfig('PROJ')
+            ->groups()
+            ->show('developers');
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/workspaces/my-workspace/projects/PROJ/permissions-config/groups/developers',
+            (string) $request->getUri()
+        );
+    }
+
+    public function testWorkspaceProjectPermissionsConfigGroupsUpdateUri(): void
+    {
+        $this->client->workspaces('my-workspace')
+            ->projects()
+            ->permissionsConfig('PROJ')
+            ->groups()
+            ->update('developers', ['permission' => 'create-repo']);
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('PUT', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/workspaces/my-workspace/projects/PROJ/permissions-config/groups/developers',
+            (string) $request->getUri()
+        );
+        $this->assertSame('{"permission":"create-repo"}', (string) $request->getBody());
+    }
+
+    public function testWorkspaceProjectPermissionsConfigGroupsRemoveUri(): void
+    {
+        $this->client->workspaces('my-workspace')
+            ->projects()
+            ->permissionsConfig('PROJ')
+            ->groups()
+            ->remove('developers');
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/workspaces/my-workspace/projects/PROJ/permissions-config/groups/developers',
+            (string) $request->getUri()
+        );
+    }
+
+    public function testWorkspaceProjectPermissionsConfigUsersListUri(): void
+    {
+        $this->client->workspaces('my-workspace')
+            ->projects()
+            ->permissionsConfig('PROJ')
+            ->users()
+            ->list(['pagelen' => 50]);
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/workspaces/my-workspace/projects/PROJ/permissions-config/users?pagelen=50',
+            (string) $request->getUri()
+        );
+    }
+
+    public function testWorkspaceProjectPermissionsConfigUsersShowUri(): void
+    {
+        $this->client->workspaces('my-workspace')
+            ->projects()
+            ->permissionsConfig('PROJ')
+            ->users()
+            ->show('{abc-123}');
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/workspaces/my-workspace/projects/PROJ/permissions-config/users/%7Babc-123%7D',
+            (string) $request->getUri()
+        );
+    }
+
+    public function testWorkspaceProjectPermissionsConfigUsersUpdateUri(): void
+    {
+        $this->client->workspaces('my-workspace')
+            ->projects()
+            ->permissionsConfig('PROJ')
+            ->users()
+            ->update('{abc-123}', ['permission' => 'admin']);
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('PUT', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/workspaces/my-workspace/projects/PROJ/permissions-config/users/%7Babc-123%7D',
+            (string) $request->getUri()
+        );
+        $this->assertSame('{"permission":"admin"}', (string) $request->getBody());
+    }
+
+    public function testWorkspaceProjectPermissionsConfigUsersRemoveUri(): void
+    {
+        $this->client->workspaces('my-workspace')
+            ->projects()
+            ->permissionsConfig('PROJ')
+            ->users()
+            ->remove('{abc-123}');
+
+        $request = $this->httpClient->getLastRequest();
+
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame(
+            'https://api.bitbucket.org/2.0/workspaces/my-workspace/projects/PROJ/permissions-config/users/%7Babc-123%7D',
+            (string) $request->getUri()
+        );
+    }
+
     public function testWorkspaceEffectiveBranchingModelShowUri(): void
     {
         $this->client->repositories()


### PR DESCRIPTION
Add project permissions-config support for explicit user and group permissions on Bitbucket projects. This mirrors the existing repository permissions-config API and exposes list, show, update, and remove operations for project users and groups.