### PR TITLE
[5.1] Mark authentication parameters sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGE LOG
 ## V5.1 (UPCOMING)
 
 * Added PHP 8.5 support
+* Added sensitive parameter annotations for authentication tokens and passwords
 * Added current user workspaces API
 * Added project permissions config APIs
 * Added repository effective branching model API

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "psr/cache": "^2.0 || ^3.0",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",
-        "psr/http-message": "^1.1 || ^2.0"
+        "psr/http-message": "^1.1 || ^2.0",
+        "symfony/polyfill-php82": "^1.27"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",

--- a/src/Client.php
+++ b/src/Client.php
@@ -151,7 +151,7 @@ class Client
     /**
      * Authenticate a user for all next requests.
      */
-    public function authenticate(string $method, string $token, ?string $password = null): void
+    public function authenticate(string $method, #[\SensitiveParameter] string $token, #[\SensitiveParameter] ?string $password = null): void
     {
         $this->getHttpClientBuilder()->removePlugin(Authentication::class);
         $this->getHttpClientBuilder()->addPlugin(new Authentication($method, $token, $password));

--- a/src/HttpClient/Plugin/Authentication.php
+++ b/src/HttpClient/Plugin/Authentication.php
@@ -32,7 +32,7 @@ final class Authentication implements Plugin
 {
     private readonly string $header;
 
-    public function __construct(string $method, string $token, ?string $password = null)
+    public function __construct(string $method, #[\SensitiveParameter] string $token, #[\SensitiveParameter] ?string $password = null)
     {
         $this->header = self::buildAuthorizationHeader($method, $token, $password);
     }
@@ -57,7 +57,7 @@ final class Authentication implements Plugin
      *
      * @throws \Bitbucket\Exception\RuntimeException
      */
-    private static function buildAuthorizationHeader(string $method, string $token, ?string $password = null): string
+    private static function buildAuthorizationHeader(string $method, #[\SensitiveParameter] string $token, #[\SensitiveParameter] ?string $password = null): string
     {
         switch ($method) {
             case Client::AUTH_HTTP_PASSWORD:


### PR DESCRIPTION
Mark authentication tokens and passwords as sensitive parameters to avoid stack-trace leaks.